### PR TITLE
fix: reduced skill-stack.yaml Polly permissions to minimum required

### DIFF
--- a/packages/sfb-cli/skill-stack.yaml
+++ b/packages/sfb-cli/skill-stack.yaml
@@ -53,7 +53,7 @@ Resources:
                     - arn:aws:s3:::SFB-STORY-ID-bucket/*
                 - Effect: Allow
                   Action:
-                    - polly:*
+                    - polly:SynthesizeSpeech
                   Resource: '*'
   AlexaSkillFunction:
     Type: AWS::Lambda::Function


### PR DESCRIPTION
Matched our CFN template Polly permissions with the documentation to just provide the minimum required (`polly:SynthesizeSpeech`)