### PR TITLE
fix: edit semantic version checking to allow nightly builds to deploy

### DIFF
--- a/packages/sfb-cli/lib/manifestUtils.ts
+++ b/packages/sfb-cli/lib/manifestUtils.ts
@@ -174,7 +174,14 @@ export class ManifestUtils {
             return;
         }
 
-        if (!semver.satisfies(toolingMetadata.version, versionRange)) {
+        const version = semver.coerce(toolingMetadata.version);
+
+        if (!version || !semver.valid(version)) {
+            logger.warning(`Found invalid version ${toolingMetadata.version} for ${frameworkName}.`);
+            return;
+        }
+
+        if (!semver.satisfies(version, versionRange)) {
             throw new Error(`Skill Flow Builder version ${toolingMetadata.version} is not compatible ` + 
             `because story's package.json specifies ${versionRangeExpression} for ${frameworkName}.`);
         }


### PR DESCRIPTION
# fix: edit semantic version checking to allow nightly builds to deploy

Edited the semantic version checking to allow nightly build to deploy correctly.

## Description

When deploying a nightly build, the version of the deployed build looks something like `2.0.1-nightly.190886605.6`. This does not get past our current version checking due to its format. This commit fixes the issue by coercing the version into the semantic `x.x.x` format. 

## Motivation and Context

Fixes the issue of nightly builds not being able to deploy correctly.

## Testing

`yarn test`

Able to successfully deploy a new story.

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [X] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [X] I have read the **README** document
- [x] I have added tests to cover my changes
- [X] All new and existing tests passed

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

[issues]: https://github.com/alexa-games/skill-flow-builder/issues
