### PR TITLE
docs: change sfb-cli readme link to skill-flow-builder

### DIFF
--- a/packages/sfb-cli/README.md
+++ b/packages/sfb-cli/README.md
@@ -4,7 +4,7 @@ This module interacts with the
 [Alexa Skills Kit (ASK)](https://developer.amazon.com/en-US/alexa/alexa-skills-kit)
 and [AWS CLI](https://github.com/aws/aws-cli) to deploy and update your skill.
 
-Visit [Skill Flow Builder](https://alexa.design/sfb-editor-landing-page) for
+Visit [Skill Flow Builder on Github](https://github.com/alexa-games/skill-flow-builder) for
 more information.
 
 ## Installation

--- a/packages/sfb-cli/README.md
+++ b/packages/sfb-cli/README.md
@@ -4,8 +4,8 @@ This module interacts with the
 [Alexa Skills Kit (ASK)](https://developer.amazon.com/en-US/alexa/alexa-skills-kit)
 and [AWS CLI](https://github.com/aws/aws-cli) to deploy and update your skill.
 
-Visit [Skill Flow Builder on Github](https://github.com/alexa-games/skill-flow-builder) for
-more information.
+Visit [Skill Flow Builder on Github](https://github.com/alexa-games/skill-flow-builder)
+for more information.
 
 ## Installation
 

--- a/packages/sfb-f/README.md
+++ b/packages/sfb-f/README.md
@@ -5,8 +5,8 @@ and driver functionalities that powers the Editor and the CLI. It handles the
 interpretation of SFB’s domain-specific language into a narrative structure,
 i.e., importing, validating, and creating interactive story skills for Alexa.
 
-Visit [Skill Flow Builder](https://alexa.design/sfb-editor-landing-page) for more
-information.
+Visit [Skill Flow Builder on Github](https://github.com/alexa-games/skill-flow-builder)
+for more information.
 
 ## Getting Started
 

--- a/packages/sfb-polly/README.md
+++ b/packages/sfb-polly/README.md
@@ -6,8 +6,8 @@ the SFB editor, and Skill Flow Builder built skills. Handles the making of
 calls out to Polly, the caching the audio files with S3, and the mixing of the
 audio responses using FFmpeg.
 
-Visit [Skill Flow Builder](https://alexa.design/sfb-editor-landing-page) for
-more information.
+Visit [Skill Flow Builder on Github](https://github.com/alexa-games/skill-flow-builder)
+for more information.
 
 ## Getting Started
 

--- a/packages/sfb-skill/README.md
+++ b/packages/sfb-skill/README.md
@@ -7,8 +7,8 @@ Alexa response to be handled by ASK. This package also includes any extensions
 that enable additional Skill interfaces, such as In-Skill Products and the
 Alexa Presentation Language.
 
-Visit [Skill Flow Builder](https://alexa.design/sfb-editor-landing-page) for
-more information.
+Visit [Skill Flow Builder on Github](https://github.com/alexa-games/skill-flow-builder)
+for more information.
 
 ## Getting Started
 

--- a/packages/sfb-story-debugger/README.md
+++ b/packages/sfb-story-debugger/README.md
@@ -4,8 +4,8 @@ The Skill Flow Builder Story Debugger. This module enables you to simulate your
 project’s behavior through the command line by running the SFB content locally,
 rather than calling a deployed skill over the network.
 
-Visit [Skill Flow Builder](https://alexa.design/sfb-editor-landing-page) for
-more information.
+Visit [Skill Flow Builder on Github](https://github.com/alexa-games/skill-flow-builder)
+for more information.
 
 ## Getting Started
 

--- a/packages/sfb-test/README.md
+++ b/packages/sfb-test/README.md
@@ -1,4 +1,4 @@
 # Skill Flow Builder Test Utilities
 
-Visit [Skill Flow Builder](https://alexa.design/sfb-editor-landing-page) for
-more information.
+Visit [Skill Flow Builder on Github](https://github.com/alexa-games/skill-flow-builder)
+for more information.

--- a/packages/sfb-vscode-extension/README.md
+++ b/packages/sfb-vscode-extension/README.md
@@ -6,8 +6,8 @@ the Skill Flow Builder CLI using the command `alexa-sfb vscode`. Using this
 command will install the Alexa SFB extension into your `$HOME/.vscode/extensions/`
 directory.
 
-Visit [Skill Flow Builder](https://alexa.design/sfb-editor-landing-page) for
-more information.
+Visit [Skill Flow Builder on Github](https://github.com/alexa-games/skill-flow-builder)
+for more information.
 
 ## Getting Started
 


### PR DESCRIPTION
# docs: change sfb-cli readme link to skill-flow-builder

Link to the correct url. 

## Motivation and Context

When reading the `README` of the `@alexa-games/sfb-cli` [npm page](https://www.npmjs.com/package/@alexa-games/sfb-cli), we should redirect them to the Github repository now that the docs are there.

## Testing

N/A

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project
- [] My change requires a change to the documentation
- [X] I have updated the documentation accordingly
- [X] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

[issues]: https://github.com/alexa-games/skill-flow-builder/issues
