### PR TITLE
fix: stop the deletion of devDependencies in stageCommand

### DIFF
--- a/packages/sfb-cli/lib/stageCommand.ts
+++ b/packages/sfb-cli/lib/stageCommand.ts
@@ -267,7 +267,6 @@ export class StageCommand implements Command {
         const lambdaPackageManifestFilePath = pathModule.join(lambdaCodeDeployPath, PACKAGE_MANIFEST_FILE);
 
         const packageManifest = JSON.parse(fs.readFileSync(pathModule.join(dirs.codePath, PACKAGE_MANIFEST_FILE), "utf8"));
-        delete packageManifest.devDependencies;
 
         // Since we're moving the manifest to a different directory for deployment, we need to updated any local runtime
         // dependencies that are using relative paths.

--- a/packages/sfb-cli/test/StageCommand.spec.ts
+++ b/packages/sfb-cli/test/StageCommand.spec.ts
@@ -304,7 +304,7 @@ describe('alexa-sfb stage', () => {
       );
     });
 
-    it('modifies package.json to remove dev dependencies and adjust local paths', async () => {
+    it('modifies package.json to adjust local paths', async () => {
       await stageCommand.run();
 
       assert.deepEqual(
@@ -314,6 +314,9 @@ describe('alexa-sfb stage', () => {
             dummy: 'dependency',
             localDependency: `file:${path.join('..', '..', '..', 'foo', 'bar')}`,
           },
+          devDependencies: {
+            another: 'dependency'
+          }
         },
       );
     });


### PR DESCRIPTION
# fix: stop the deletion of devDependencies in stageCommand

## Description

Instead of delete devDependenices manually, we should probably rely on ASK CLI V2 to do npm install --production

## Motivation and Context

Remove unneeded lines of code.

## Testing

`yarn test`.

Deployed a story with the line deleted and deployed a story as is. Both produced the same result with the same lambda file size.

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [X] I have read the **README** document
- [ ] I have added tests to cover my changes
- [X] All new and existing tests passed

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

[issues]: https://github.com/alexa-games/skill-flow-builder/issues
