### PR TITLE
fix: alexa-sfb vscode when installed locally

### DIFF
--- a/packages/sfb-cli/lib/vscodeExtensionCommand.ts
+++ b/packages/sfb-cli/lib/vscodeExtensionCommand.ts
@@ -65,14 +65,18 @@ export class VscodeExtensionCommand implements Command {
 
         const packageMatch = new RegExp(/^@alexa-games\/(sfb-[a-z].*)/);
 
+        let manifestModified = false;
         for (const dependency in packageJson.dependencies) {
             const match = packageMatch.exec(dependency);
             if (packageJson.dependencies[dependency].startsWith('file:') && match) {
                 packageJson.dependencies[dependency] = `file:${pathModule.join(dirs.sfbRootPath, '..', match[1])}`;
+                manifestModified = true;
             }
         }
 
-        fs.writeFileSync(pathModule.join(vscodeExtDestPath, PACKAGE_MANIFEST_FILE), JSON.stringify(packageJson, null, 4));
+        if (manifestModified) {
+            fs.writeFileSync(pathModule.join(vscodeExtDestPath, PACKAGE_MANIFEST_FILE), JSON.stringify(packageJson, null, 4));
+        }
 
         // Ensure module is fully resolved once moved. Do this in the destination since user won't need to be root.
         await Utilities.runCommandInDirectoryAsync(

--- a/packages/sfb-cli/lib/vscodeExtensionCommand.ts
+++ b/packages/sfb-cli/lib/vscodeExtensionCommand.ts
@@ -74,6 +74,7 @@ export class VscodeExtensionCommand implements Command {
 
         fs.writeFileSync(pathModule.join(vscodeExtDestPath, PACKAGE_MANIFEST_FILE), JSON.stringify(packageJson, null, 4));
 
+        // Ensure module is fully resolved once moved. Do this in the destination since user won't need to be root.
         await Utilities.runCommandInDirectoryAsync(
             Utilities.npxBin,
             ['npm', 'install', '--production'],

--- a/packages/sfb-cli/lib/vscodeExtensionCommand.ts
+++ b/packages/sfb-cli/lib/vscodeExtensionCommand.ts
@@ -21,7 +21,7 @@ import { PACKAGE_MANIFEST_FILE, SpecialPaths } from './specialPaths';
 import { Logger } from './logger';
 import { StdOutput } from './stdOutput';
 import { Command } from './command';
-import { existsSync, fstat, readdirSync } from 'fs';
+import { existsSync } from 'fs';
 
 const pathModule = require('path');
 const fs = require('fs');

--- a/packages/sfb-cli/lib/vscodeExtensionCommand.ts
+++ b/packages/sfb-cli/lib/vscodeExtensionCommand.ts
@@ -67,7 +67,6 @@ export class VscodeExtensionCommand implements Command {
 
         for (const dependency in packageJson.dependencies) {
             const match = packageMatch.exec(dependency);
-            console.log(packageJson.dependencies[dependency]);
             if (packageJson.dependencies[dependency].startsWith('file:') && match) {
                 packageJson.dependencies[dependency] = `file:${pathModule.join(dirs.sfbRootPath, '..', match[1])}`;
             }

--- a/packages/sfb-cli/lib/vscodeExtensionCommand.ts
+++ b/packages/sfb-cli/lib/vscodeExtensionCommand.ts
@@ -54,17 +54,16 @@ export class VscodeExtensionCommand implements Command {
             vscodeExtSoucePath = pathModule.join(dirs.sfbRootPath, '..', SFB_VSCODE_EXTENSION);
         }
 
-        await FileUtils.recursiveCopy(
-            pathModule.join(vscodeExtSoucePath, '*'), 
-            vscodeExtDestPath);
-
-        // Ensure module is fully resolved once moved. Do this in the destination since user won't need to be root.
         await Utilities.runCommandInDirectoryAsync(
             Utilities.npxBin,
             [ 'npm', 'install', '--production' ],
-            vscodeExtDestPath,
+            vscodeExtSoucePath,
             this.stdOutput,
             { shell: true });
+
+        await FileUtils.recursiveCopy(
+            pathModule.join(vscodeExtSoucePath, '*'),
+            vscodeExtDestPath);
 
         this.logger.success('Success. Restart vscode to pickup extension features.');
     }

--- a/packages/sfb-cli/test/VSCodeExtensionCommand.spec.ts
+++ b/packages/sfb-cli/test/VSCodeExtensionCommand.spec.ts
@@ -52,7 +52,14 @@ describe('alexa-sfb vscode', () => {
         node_modules: {
           ['@alexa-games']: {
             [SFB_VSCODE_EXTENSION_NAME]: { // Directory to copy the extension from
-              'dummy-file': 'dummy-contents'
+              'dummy-file': 'dummy-contents',
+              'package.json': JSON.stringify({
+                "dependencies": {
+                  "dummy-dependency": "// dummy dependency",
+                  "@alexa-games/sfb-util": "file:../dummy/local/reference",
+                  "@alexa-games/sfb-f": "^1.2.3" // Simulated remote location
+                }
+              }, null, 4)
             }
           }
         }
@@ -85,6 +92,18 @@ describe('alexa-sfb vscode', () => {
     );
 
     assert.equal(readTextFile(vscodeExtDestPath + '/dummy-file'), 'dummy-contents');
+  });
+
+  it('fixes the local module references', async () => {
+    await vscodeExtension.run();
+
+    const expectedDependencies = {
+      "dummy-dependency": "// dummy dependency",
+      "@alexa-games/sfb-util": "file:/home/sfb-util", // Expected local reference
+      "@alexa-games/sfb-f": "^1.2.3" // Dummy remote location
+    }
+
+    assert.deepEqual(JSON.parse(readTextFile(vscodeExtDestPath + '/package.json')).dependencies, expectedDependencies);
   });
 
   it('ensures the extension is fully resolved', async () => {

--- a/packages/sfb-cli/test/VSCodeExtensionCommand.spec.ts
+++ b/packages/sfb-cli/test/VSCodeExtensionCommand.spec.ts
@@ -90,9 +90,9 @@ describe('alexa-sfb vscode', () => {
   it('ensures the extension is fully resolved', async () => {
     await vscodeExtension.run();
 
-    const vscodeSrcPath = path.resolve(path.join(homeDir, 'sfb-cli', 'node_modules', '@alexa-games', 'sfb-vscode-extension'));
+    const vscodeExtSrcPath = path.join(homeDir, 'sfb-cli', 'node_modules', '@alexa-games', 'sfb-vscode-extension');
     assertCalledManyTimesWithArgs(mockSpawn, [
-      ['npx', ['npm', 'install', '--production'], { cwd: `${path.resolve(vscodeSrcPath)}`, shell: true}]
+      ['npx', ['npm', 'install', '--production'], { cwd: `${vscodeExtSrcPath}`, shell: true}]
     ]);
   });
 });

--- a/packages/sfb-cli/test/VSCodeExtensionCommand.spec.ts
+++ b/packages/sfb-cli/test/VSCodeExtensionCommand.spec.ts
@@ -99,9 +99,9 @@ describe('alexa-sfb vscode', () => {
 
     const expectedDependencies = {
       "dummy-dependency": "// dummy dependency",
-      "@alexa-games/sfb-util": "file:/home/sfb-util", // Expected local reference
-      "@alexa-games/sfb-f": "^1.2.3" // Dummy remote location
-    }
+      "@alexa-games/sfb-util": `file:${path.join(DUMMY_SFB_ROOT, '..')}/sfb-util`, // Expected local reference
+      "@alexa-games/sfb-f": "^1.2.3" // Simulated remote location
+    };
 
     assert.deepEqual(JSON.parse(readTextFile(vscodeExtDestPath + '/package.json')).dependencies, expectedDependencies);
   });

--- a/packages/sfb-cli/test/VSCodeExtensionCommand.spec.ts
+++ b/packages/sfb-cli/test/VSCodeExtensionCommand.spec.ts
@@ -90,8 +90,9 @@ describe('alexa-sfb vscode', () => {
   it('ensures the extension is fully resolved', async () => {
     await vscodeExtension.run();
 
+    const vscodeSrcPath = path.resolve(path.join(homeDir, 'sfb-cli', 'node_modules', '@alexa-games', 'sfb-vscode-extension'));
     assertCalledManyTimesWithArgs(mockSpawn, [
-      ['npx', ['npm', 'install', '--production'], { cwd: `${path.resolve(vscodeExtDestPath)}`, shell: true}]
+      ['npx', ['npm', 'install', '--production'], { cwd: `${path.resolve(vscodeSrcPath)}`, shell: true}]
     ]);
   });
 });

--- a/packages/sfb-cli/test/VSCodeExtensionCommand.spec.ts
+++ b/packages/sfb-cli/test/VSCodeExtensionCommand.spec.ts
@@ -99,7 +99,7 @@ describe('alexa-sfb vscode', () => {
 
     const expectedDependencies = {
       "dummy-dependency": "// dummy dependency",
-      "@alexa-games/sfb-util": `file:${path.join(DUMMY_SFB_ROOT, '..')}/sfb-util`, // Expected local reference
+      "@alexa-games/sfb-util": `file:${path.join(DUMMY_SFB_ROOT, '..', 'sfb-util')}`, // Expected local reference
       "@alexa-games/sfb-f": "^1.2.3" // Simulated remote location
     };
 

--- a/packages/sfb-cli/test/VSCodeExtensionCommand.spec.ts
+++ b/packages/sfb-cli/test/VSCodeExtensionCommand.spec.ts
@@ -28,14 +28,14 @@ import { ConsoleLogger } from '../lib/consoleLogger';
 import { ConsoleStdOutput } from '../lib/consoleStdOutput';
 
 import {
-    createMockSpawn,
-    assertCalledManyTimesWithArgs,
-    stubSfbCliRoot,
-    readTextFile,
-    DUMMY_SFB_ROOT,
-    SFB_VSCODE_EXTENSION_NAME,
-    isWin32
-  } from './testUtilities';
+  createMockSpawn,
+  assertCalledManyTimesWithArgs,
+  stubSfbCliRoot,
+  readTextFile,
+  DUMMY_SFB_ROOT,
+  SFB_VSCODE_EXTENSION_NAME,
+  isWin32
+} from './testUtilities';
 
 describe('alexa-sfb vscode', () => {
   let dummyFileSystem: any;
@@ -44,7 +44,7 @@ describe('alexa-sfb vscode', () => {
 
   let homeDir = isWin32() ? '\\home' : '/home';
 
-  beforeEach(() => {  
+  beforeEach(() => {
     sinon.stub(process, 'env').value({ HOME: homeDir, USERPROFILE: homeDir });
 
     mockFileSystem({
@@ -58,7 +58,7 @@ describe('alexa-sfb vscode', () => {
         }
       }
     });
-    
+
     stubSfbCliRoot();
 
     mockSpawn = createMockSpawn();
@@ -90,9 +90,8 @@ describe('alexa-sfb vscode', () => {
   it('ensures the extension is fully resolved', async () => {
     await vscodeExtension.run();
 
-    const vscodeExtSrcPath = path.join(homeDir, 'sfb-cli', 'node_modules', '@alexa-games', 'sfb-vscode-extension');
     assertCalledManyTimesWithArgs(mockSpawn, [
-      ['npx', ['npm', 'install', '--production'], { cwd: `${vscodeExtSrcPath}`, shell: true}]
+      ['npx', ['npm', 'install', '--production'], { cwd: `${vscodeExtDestPath}`, shell: true }]
     ]);
   });
 });


### PR DESCRIPTION
# fix: alexa-sfb vscode when installed locally

When installed locally, `alexa-sfb vscode` errors out with problems accessing local reference paths `file:../sfb-f`, `file:../sfb-util`, ...etc. 

## Description

When the CLI is installed locally, edit the `package.json` to point towards the modules before running `npm install --production` so we still can reference those local file paths.

Edited related test(s).

## Motivation and Context

Stop `alexa-sfb vscode` from erroring out on a local install.

## Testing

`alexa-sfb vscode`
`yarn test`

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [X] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [X] I have read the **README** document
- [ ] I have added tests to cover my changes
- [X] All new and existing tests passed

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

[issues]: https://github.com/alexa-games/skill-flow-builder/issues
