### PR TITLE
fix: Removed unnecessary async in test

### DIFF
--- a/packages/sfb-editor/test/actions/project.integ.spec.js
+++ b/packages/sfb-editor/test/actions/project.integ.spec.js
@@ -88,7 +88,7 @@ function printAllLogMessagesToConsole(actionValues) {
   });
 }
 
-describe('Project integration tests', async () => {
+describe('Project integration tests', () => {
   beforeAll(() => {
     jest.spyOn(extensionLoaders, 'getCustomExtensionLoader')
       .mockImplementation((customExtensionPath, locale, storyConfigPath, contentSource) => {


### PR DESCRIPTION
# fix: Removed unnecessary async in test

## Description

Removed an unnecessary async flag in one of the integration tests that was causing `jest` to hang on Node 12 and 14

## Motivation and Context

The editor tests are hanging on some versions of Node after the upgrade to `jest`

## Testing

`yarn test`

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

[issues]: https://github.com/alexa-games/skill-flow-builder/issues
