### PR TITLE
feat: Include S3 domain and default to HTTPS for VoiceOverExtension

### DIFF
--- a/packages/sfb-f/extensions/coreExtensions/VoiceOverExtension.ts
+++ b/packages/sfb-f/extensions/coreExtensions/VoiceOverExtension.ts
@@ -16,7 +16,7 @@
  */
 
 
-import * as _http from 'http';
+import * as _https from 'https';
 import * as url from 'url';
 import { ImporterExtension } from '../SFBExtension';
 import { SourceContentHelper } from '../../importPlugins/sourceContentHelper';
@@ -29,7 +29,7 @@ async function urlExists(urlString : string, http: any): Promise<boolean> {
         let options: any = {
             method: 'HEAD',
             host: url.parse(urlString).host,
-            port: 80,
+            port: 443,
             path: url.parse(urlString).pathname
         };
     
@@ -57,7 +57,7 @@ export class VoiceOverExtension implements ImporterExtension {
     public constructor(urlFormat: string, http?: any) {
         this.urlFormat = urlFormat;
         this.recordingScript = "";
-        this.http =  http || _http;
+        this.http =  http || _https;
     }
 
     async extendSourceContent(sourceHelper: SourceContentHelper): Promise<void> {

--- a/packages/sfb-skill/src/handler/CoreExtensionLoader.ts
+++ b/packages/sfb-skill/src/handler/CoreExtensionLoader.ts
@@ -50,9 +50,10 @@ export class CoreExtensionLoader {
 
     constructor(locale: string, configAccessor: ConfigAccessor, param: CoreExtensionLoaderParams) {
         const s3ResourcesUri = configAccessor.getS3ResourcesUri(locale);
-        const s3BuketName = configAccessor.getS3BucketName(locale);
+        const s3BucketName = configAccessor.getS3BucketName(locale);
+        const s3DomainName = configAccessor.getS3DomainName(locale);
 
-        this.voiceOverExtension = new SFBExtension.VoiceOverExtension(`https://${s3BuketName}.s3.amazonaws.com/vo/{{file_name}}`);
+        this.voiceOverExtension = new SFBExtension.VoiceOverExtension(`https://${s3BucketName}.${s3DomainName}/vo/{{file_name}}`);
 
         let globalSceneExceptions: string[] = []; // list of scene names which should not have the global scene applied.
 


### PR DESCRIPTION
# Include S3 domain and default to HTTPS for VoiceOverExtension

## Description

Add `s3-domain-name` to the URL used for the VoiceOverExtension during the SFB CLI import command. Also updated the urlExists command in the VoiceOverExtension to default to port 443 for HTTPS.

## Motivation and Context

Customers can override the S3 domain to support multiple regions, so the VoiceOverExtension should support that as well. HTTPS is more secure than HTTP, so it makes sense to default to it in this case as S3 buckets support and prefer HTTPS.

## Testing

`yarn test` - includes integration test for existing URL examples.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

[issues]: https://github.com/alexa-games/skill-flow-builder/issues
