### PR TITLE
feat: Added ability to use ASK custom build hooks for local package linking

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,43 @@ This will launch the SFB editor, which will visualize your skill’s behavior an
 content. You can create a new project, or open an existing project using the
 buttons on the top left.
 
+### Using Modifications to Core Libraries
+
+If you want to use any modifications to the core SFB libraries, you must add them
+all as a local file path dependency in your skill's `code/package.json` file.
+
+```json
+...
+"dependencies": {
+    "@alexa-games/sfb-f": "file:/path/to/skill-flow-builder/packages/sfb-f",
+    "@alexa-games/sfb-polly": "file:/path/to/skill-flow-builder/packages/sfb-polly",
+    "@alexa-games/sfb-skill": "file:/path/to/skill-flow-builder/packages/sfb-skill",
+    "@alexa-games/sfb-util": "file:/path/to/skill-flow-builder/packages/sfb-util",
+    "ask-sdk": "latest"
+},
+...
+```
+
+Next, add the `sfbLocalTesting` and `ask-hooks-directory` property to your
+abcConfig.json file:
+
+```json
+...
+"default": {
+    ...
+    "sfbLocalTesting": true,
+    "ask-hooks-directory": "hooks",
+    ...
+}
+...
+```
+
+Finally, copy the `scripts/local-packages/hooks` folder into your SFB project
+folder (i.e. there should be a `hooks` folder at the same level as your `code` and
+`content` folders). These two changes will force the SFB CLI and the ASK CLI to
+use `yarn` instead of `npm` when building your skill, allowing you to properly
+reference the local dependency packages.
+
 ## Security
 
 See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more information.

--- a/packages/sfb-cli/lib/specialPaths.ts
+++ b/packages/sfb-cli/lib/specialPaths.ts
@@ -44,6 +44,7 @@ export const CLOUDFORMATION_TEMPLATE = 'skill-stack.yaml';
 export const LAMBDA_LAYER_DIRECTORY = 'lambda-layer';
 export const LAMBDA_LAYER_MODULE_DIRECTORY = 'nodejs';
 export const LAMBDA_LAYER_CONFIG_FILE = 'lambda-layer.json';
+export const HOOKS_DIRECTORY = 'hooks';
 
 export interface ConfigPaths {
     askSkillDirectoryName: string;
@@ -160,5 +161,11 @@ export class SpecialPaths {
         return SpecialPaths.isAskCliV1(configPaths)
             ? pathModule.join(configPaths.askSkillFullPath, 'models')
             : pathModule.join(configPaths.skillPackagePath, 'interactionModels', 'custom');
+    }
+
+    public static getAskLambdaCodeDeployPath(configPaths: ConfigPaths) {
+        return SpecialPaths.isAskCliV1(configPaths)
+        ? SpecialPaths.getLambdaCodeDeployPath(configPaths)
+        : pathModule.join(configPaths.askSkillFullPath, ASK_METADATA_DIRECTORY, 'lambda')
     }
 }

--- a/packages/sfb-cli/lib/specialPaths.ts
+++ b/packages/sfb-cli/lib/specialPaths.ts
@@ -166,6 +166,6 @@ export class SpecialPaths {
     public static getAskLambdaCodeDeployPath(configPaths: ConfigPaths) {
         return SpecialPaths.isAskCliV1(configPaths)
         ? SpecialPaths.getLambdaCodeDeployPath(configPaths)
-        : pathModule.join(configPaths.askSkillFullPath, ASK_METADATA_DIRECTORY, 'lambda')
+        : pathModule.join(configPaths.askSkillFullPath, ASK_METADATA_DIRECTORY, 'lambda');
     }
 }

--- a/packages/sfb-cli/lib/stageCommand.ts
+++ b/packages/sfb-cli/lib/stageCommand.ts
@@ -224,7 +224,7 @@ export class StageCommand implements Command {
         
         await this.adjustLocalDependencyPaths(dirs, configDirs, lambdaCodeDeployPath);
 
-        const hooksDestPath = FileUtils.fixpath(pathModule.join(configDirs.askSkillFullPath, HOOKS_DIRECTORY))
+        const hooksDestPath = FileUtils.fixpath(pathModule.join(configDirs.askSkillFullPath, HOOKS_DIRECTORY));
         if (fs.existsSync(hooksDestPath)) {
             await FileUtils.deleteDir(hooksDestPath, this.stdOutput);
         }

--- a/packages/sfb-cli/lib/stageCommand.ts
+++ b/packages/sfb-cli/lib/stageCommand.ts
@@ -21,6 +21,7 @@ import {
     PACKAGE_MANIFEST_FILE,
     SKILL_MANIFEST_FILE,
     CLOUDFORMATION_TEMPLATE,
+    HOOKS_DIRECTORY,
 } from './specialPaths';
 import { Utilities } from './utilities';
 import { Logger } from './logger';
@@ -40,6 +41,7 @@ const SFB_ENV_VAR_PLACEHOLDER = "SFB-ENVIRONMENT-VARIABLES"
 
 const SKIP_FFMPEG_COPY_PROPERTY = "skipFFMPEGInclude";
 const SKILL_FFMPEG_LOCATION_PROPERTY = "ffmpeg-location-for-skill";
+const HOOKS_DIRECTORY_PROPERTY = "ask-hooks-directory";
 
 /**
  * Gathers all files to the deployment folder.
@@ -219,8 +221,19 @@ export class StageCommand implements Command {
         await FileUtils.recursiveCopy(pathModule.join(dirs.buildOutputPath, '*'), lambdaCodeDeployPath, { makeDestinationWritable: true });
 
         await FileUtils.recursiveCopy(pathModule.join(dirs.codeBuildOutputPath, '*'), lambdaCodeDeployPath, { makeDestinationWritable: true });
+        
+        await this.adjustLocalDependencyPaths(dirs, configDirs, lambdaCodeDeployPath);
 
-        await this.setupNodeModulesUsingInstallProduction(dirs, lambdaCodeDeployPath, configHelper.getValue("sfbLocalTesting", undefined, "en-US"));
+        const hooksDestPath = FileUtils.fixpath(pathModule.join(configDirs.askSkillFullPath, HOOKS_DIRECTORY))
+        if (fs.existsSync(hooksDestPath)) {
+            await FileUtils.deleteDir(hooksDestPath, this.stdOutput);
+        }
+        
+        const hooksDirectoryName = configHelper.getValue(HOOKS_DIRECTORY_PROPERTY, undefined, "en-US");
+        if (hooksDirectoryName) {
+            const hooksSrcPath = FileUtils.fixpath(pathModule.join(this.storyPath, hooksDirectoryName));
+            await FileUtils.recursiveCopy(pathModule.join(hooksSrcPath, '*'), hooksDestPath, { makeDestinationWritable: true });
+        }
 
         if(!configHelper.getValue(SKIP_FFMPEG_COPY_PROPERTY, undefined, "en-US")) {
             let srcFFmpegPath = configHelper.getValue(SKILL_FFMPEG_LOCATION_PROPERTY, undefined, "en-US");
@@ -249,55 +262,42 @@ export class StageCommand implements Command {
             if (fs.existsSync(modelOutput)) {
                 fs.copyFileSync(modelOutput, pathModule.join(modelsDeployPath, `${locale}.json`));
             } else {
-                this.logger.status(`${modelOutput} does not exist.`)
+                this.logger.status(`${modelOutput} does not exist.`);
                 failure = true;
             }
         }
 
         if (failure) {
-            throw new Error('Error copying models to deployment folder.')
+            throw new Error('Error copying models to deployment folder.');
         }
 
         this.logger.success('Story specific files copied over.');
     }
 
-    private async setupNodeModulesUsingInstallProduction(dirs: SpecialPaths, lambdaCodeDeployPath: string, isLocalTest: boolean) {
-        this.logger.status('Installing production node_modules...');
-
-        const lambdaPackageManifestFilePath = pathModule.join(lambdaCodeDeployPath, PACKAGE_MANIFEST_FILE);
+    private async adjustLocalDependencyPaths(dirs: SpecialPaths, configDirs: ConfigPaths, lambdaCodeDeployPath: string) {
+        this.logger.status('Adjusting local dependency paths...');
 
         const packageManifest = JSON.parse(fs.readFileSync(pathModule.join(dirs.codePath, PACKAGE_MANIFEST_FILE), "utf8"));
 
-        // Since we're moving the manifest to a different directory for deployment, we need to updated any local runtime
-        // dependencies that are using relative paths.
-        for (const [name, path] of Object.entries(packageManifest.dependencies as Record<string, string>)) {
+        const askLambdaCodeDeployPath = SpecialPaths.getAskLambdaCodeDeployPath(configDirs);
+
+        this.adjustDependencyRelativePaths(dirs, askLambdaCodeDeployPath, packageManifest.dependencies);
+        this.adjustDependencyRelativePaths(dirs, askLambdaCodeDeployPath, packageManifest.devDependencies);
+
+        const lambdaPackageManifestFilePath = pathModule.join(lambdaCodeDeployPath, PACKAGE_MANIFEST_FILE);
+        fs.writeFileSync(lambdaPackageManifestFilePath, JSON.stringify(packageManifest, null, 4));
+    }
+
+    private adjustDependencyRelativePaths(dirs: SpecialPaths, lambdaCodeDeployPath: string, dependencies: any): void {
+        for (const [name, path] of Object.entries(dependencies as Record<string, string>)) {
             if (path.match(/^file:[^\/]/)) { // package path starts with non-root file path -> relative local dependency
                 const relativePath = path.replace(/^file:/, '');
                 const absolutePath = pathModule.resolve(dirs.codePath, relativePath);
                 // Adjust the relative path for the deployment path we're moving the manifest to.
                 const adjustedRelativePath = pathModule.relative(lambdaCodeDeployPath, absolutePath);
                 // Updated the manifest with the corrected relative path.
-                packageManifest.dependencies[name] = `file:${adjustedRelativePath}`;
+                dependencies[name] = `file:${adjustedRelativePath}`;
             }
-        }
-
-        fs.writeFileSync(lambdaPackageManifestFilePath, JSON.stringify(packageManifest, null, 4));
-        // End of alternate solution
-
-        if (isLocalTest) {
-            await Utilities.runCommandInDirectoryAsync(
-                Utilities.npxBin,
-                [ Utilities.yarnBin, 'install', '--production' ],
-                lambdaCodeDeployPath,
-                this.stdOutput,
-                {shell: true});
-        } else {
-            await Utilities.runCommandInDirectoryAsync(
-                Utilities.npmBin,
-                [ 'install', '--production' ],
-                lambdaCodeDeployPath,
-                this.stdOutput,
-                {shell: true});
         }
     }
 

--- a/packages/sfb-cli/test/StageCommand.spec.ts
+++ b/packages/sfb-cli/test/StageCommand.spec.ts
@@ -152,6 +152,10 @@ describe('alexa-sfb stage', () => {
       },
     };
 
+    dummyFileSystem[STORY_DIR]['dummy-hooks'] = {
+      'build.sh': 'dummy build script'
+    };
+
     // Sample CloudFormation template in the SFB CLI installation location
     dummyFileSystem[DUMMY_SFB_ROOT] = {
       'skill-stack.yaml': SAMPLE_CLOUDFORMATION_TEMPLATE,
@@ -253,8 +257,7 @@ describe('alexa-sfb stage', () => {
           ],
           { shell: true, cwd: path.resolve(BUILD_ARTIFACT_PATH) },
         ],
-        [REMOVE_DIR_COMMAND, [...REMOVE_FLAGS, `"${path.resolve(path.join(ASK_SKILL_DIRECTORY_PATH, 'lambda'))}"`], { shell: true }],
-        ['npm', ['install', '--production'], { shell: true, cwd: `${path.resolve(path.join(ASK_SKILL_DIRECTORY_PATH, 'lambda'))}` }],
+        [REMOVE_DIR_COMMAND, [...REMOVE_FLAGS, `"${path.resolve(path.join(ASK_SKILL_DIRECTORY_PATH, 'lambda'))}"`], { shell: true }]
       ]);
     });
 
@@ -312,7 +315,7 @@ describe('alexa-sfb stage', () => {
         {
           dependencies: {
             dummy: 'dependency',
-            localDependency: `file:${path.join('..', '..', '..', 'foo', 'bar')}`,
+            localDependency: `file:${path.join('..', '..', '..', '..', 'foo', 'bar')}`,
           },
           devDependencies: {
             another: 'dependency'
@@ -376,6 +379,47 @@ describe('alexa-sfb stage', () => {
         JSON.parse(readTextFile(`${metadataDir}/skill.json`)),
         JSON.parse(readTextFile(STAGED_SKILL_JSON_PATH)),
       );
+    });
+
+    it('stages hooks if ask-hooks-directory is defined', async () => {
+      const abcConfig = JSON.parse(dummyFileSystem[STORY_DIR]['abcConfig.json']);
+      abcConfig.default['ask-hooks-directory'] = 'dummy-hooks';
+      dummyFileSystem[STORY_DIR]['abcConfig.json'] = JSON.stringify(abcConfig);
+
+      reMockFileSystem(dummyFileSystem);
+
+      await stageCommand.run();
+
+      assert.equal(
+        readTextFile(`${ASK_SKILL_DIRECTORY_PATH}/hooks/build.sh`),
+        'dummy build script',
+      );
+    });
+
+    it('deletes previous hooks directory if redeployed', async () => {
+      // mock previously deployed state
+      dummyFileSystem[STORY_DIR]['.deploy'] = {
+        'dist': {
+          'abcConfig': dummyFileSystem[STORY_DIR]['abcConfig.json'],
+          'res': {
+            'en-US': {
+              'en-US.json': 'dummy en-US interaction model'
+            },
+            'en-GB': {
+              'en-GB.json': 'dummy en-GB interaction model'
+            }
+          }
+        },
+        ASK_SKILL_DIRECTORY_NAME: {
+          'hooks': {
+            'old-build.sh': 'this should be deleted'
+          }
+        }
+      };
+
+      await stageCommand.run();
+
+      assert.ok(!fs.existsSync(`${ASK_SKILL_DIRECTORY_PATH}/hooks/old-build.sh`));
     });
   };
 
@@ -484,9 +528,7 @@ describe('alexa-sfb stage', () => {
       await stageCommand.run();
 
       // ASK CLI calls are never made
-      assertCalledManyTimesWithArgs(mockSpawn, [
-        ['npm', ['install', '--production'], { shell: true, cwd: `${path.resolve(path.join(ASK_SKILL_DIRECTORY_PATH, 'lambda'))}` }],
-      ]);
+      assertCalledManyTimesWithArgs(mockSpawn, []);
     });
   });
 

--- a/packages/sfb-skill/src/configAccessor.ts
+++ b/packages/sfb-skill/src/configAccessor.ts
@@ -114,7 +114,7 @@ export class ConfigAccessor {
     }
 
     public getSnippetMapFilePath(locale: string): string {
-        return path.join(this.getResourcePath(locale), this.getValue("snippet-map-filename", undefined, locale));;
+        return path.join(this.getResourcePath(locale), this.getValue("snippet-map-filename", undefined, locale));
     }
 
     public getAskSkillPath(locale: string): string {

--- a/scripts/local-packages/hooks/build.ps1
+++ b/scripts/local-packages/hooks/build.ps1
@@ -1,5 +1,3 @@
-#!/usr/bin/env bash
-
 # Copyright 2020 Amazon.com, Inc. and its affiliates. All Rights Reserved.
 #
 # SPDX-License-Identifier: LicenseRef-.amazon.com.-AmznSL-1.0
@@ -15,7 +13,5 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-set -euo pipefail
-
 npx yarn install --production
-zip -r $1 *
+7z a -r $args[0] *

--- a/scripts/local-packages/hooks/build.sh
+++ b/scripts/local-packages/hooks/build.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# Copyright 2020 Amazon.com, Inc. and its affiliates. All Rights Reserved.
+#
+# SPDX-License-Identifier: LicenseRef-.amazon.com.-AmznSL-1.0
+#
+# Licensed under the Amazon Software License (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#   http://aws.amazon.com/asl/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+set -euo pipefail
+
+yarn install --production --quite
+zip -r $1 *


### PR DESCRIPTION
# Added ability to use ASK custom build hooks for local package linking

## Description

Added 'ask-hooks-directory' property to abcConfig.json to specify a directory containing build hooks for the ASK CLI. If this property is present, then the contents of the given directory will be copied into the `.deploy/story-id/hooks` directory during staging. Also added an example `build.sh` that uses `yarn` instead of `npm` and added instructions to the top-level README describing how to link local packages.

## Motivation and Context

The SFB repo relies on `yarn` to handle local package dependencies, this makes it easier to test and use modifications made to the SFB packages locally.

## Testing

Deployed a sample skill with local package modifications to multiple stages, ran the skill stages and verified that altered behavior was as expected.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

[issues]: https://github.com/alexa-games/skill-flow-builder/issues
