### PR TITLE
chore: removed axios as a dependency for sfb-editor

### DIFF
--- a/packages/sfb-editor/package.json
+++ b/packages/sfb-editor/package.json
@@ -234,7 +234,6 @@
     "@alexa-games/sfb-skill": "file:../sfb-skill",
     "@alexa-games/sfb-story-debugger": "file:../sfb-story-debugger",
     "@alexa-games/sfb-util": "file:../sfb-util",
-    "axios": "^0.19.0",
     "bumpit": "^1.0.2",
     "commander": "^2.19.0",
     "connected-react-router": "^5.0.1",


### PR DESCRIPTION
# Removed axios as a dependency for sfb-editor

## Description

Removed `axios` as an npm dependency in the sfb-editor package.

## Motivation and Context

Axios is no longer used as an HTTP client for the SFB editor and can be safely removed.

## Testing

Ran the editor, checking all tabs and running the voice preview simulator.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

[issues]: https://github.com/alexa-games/skill-flow-builder/issues
