### PR TITLE
chore(deps): Removing unused editor dependency

### DIFF
--- a/packages/sfb-editor/package.json
+++ b/packages/sfb-editor/package.json
@@ -237,7 +237,6 @@
     "css-loader": "~1.0.1",
     "d3": "~5.9.2",
     "detect-port": "~1.3.0",
-    "devtron": "~1.4.0",
     "electron-debug": "~2.0.0",
     "electron-log": "~2.2.17",
     "electron-settings": "~3.2.0",


### PR DESCRIPTION
# Removing unused devtron dependency

<!--- Provide a general summary of your changes in the Title above. -->

## Devtron is deprecated and not being used in skill-flow-builder. This change simply removes it.

<!--- Describe your changes in detail. -->

## Removed the unused dependency, verified no regressions.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it addresses an open [issue][issues], please link here. -->

## Testing

Verified build and skill creation from editor.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [X] I have read the **README** document
- [ ] I have added tests to cover my changes
- [X] All new and existing tests passed

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

[issues]: https://github.com/alexa-games/skill-flow-builder/issues
