### PR TITLE
fix: Do not sanitize backslash on Windows

### DIFF
--- a/packages/sfb-util/test/utilities.spec.ts
+++ b/packages/sfb-util/test/utilities.spec.ts
@@ -78,7 +78,7 @@ describe('utilities', () => {
             if (isWin32) {
                 assert.equal(actual, 'fake \\ && rm -rf / && echo ');
             } else {
-                assert.equal(actual, 'fake && rm -rf / && echo ');
+                assert.equal(actual, 'fake  && rm -rf / && echo ');
             }
         });
 

--- a/packages/sfb-util/test/utilities.spec.ts
+++ b/packages/sfb-util/test/utilities.spec.ts
@@ -66,9 +66,20 @@ describe('utilities', () => {
         });
 
         it('removes line breaks', () => {
-            const actual = sanitizeCommandLineParameter('fake\\\r\n" && rm -rf / && echo "');
+            const actual = sanitizeCommandLineParameter('fake\r\n" && rm -rf / && echo "');
 
             assert.equal(actual, 'fake && rm -rf / && echo ');
+        });
+
+        it('removes backslash on non-Windows OS', () => {
+            const actual = sanitizeCommandLineParameter('fake \\ && rm -rf / && echo "');
+
+            const isWin32 = (process.platform === "win32");
+            if (isWin32) {
+                assert.equal(actual, 'fake \\ && rm -rf / && echo ');
+            } else {
+                assert.equal(actual, 'fake && rm -rf / && echo ');
+            }
         });
 
         it('removes environment variable syntax', () => {

--- a/packages/sfb-util/utilities.ts
+++ b/packages/sfb-util/utilities.ts
@@ -56,5 +56,9 @@ export function sanitizeCommandLineParameter(parameterValue: string | number): s
     if (parameterValue === null || parameterValue === undefined) {
         throw new Error('parameterValue must have a value');
     }
+    const isWin32 = (process.platform === "win32");
+    if (isWin32) {
+        return parameterValue.toString().replace(/["'${}\r\n]/g, '');
+    }
     return parameterValue.toString().replace(/[\\"'${}\r\n]/g, '');
 }


### PR DESCRIPTION
# Title

fix: Do not sanitize backslash on Windows

## Description

`sanitizeCommandLineParameter` no longer removes backslash `\` on Windows.

## Motivation and Context

On Windows machines, we should not be removing backslash when sanitizing command-line inputs because backslash is a valid path separator on Windows.

## Testing

Built on Windows, ran unit tests, simulated skill

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

[issues]: https://github.com/alexa-games/skill-flow-builder/issues
